### PR TITLE
Fix start script and static asset path

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ app.use(
 );
 
 app.use(flash());
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Templating engine
 app.use(expressLayout);
@@ -59,8 +59,6 @@ app.use((req, res, next) => {
 
 app.use('/', MainRouter);
 app.use('/', AdminRouter);
-
-app.use(express.static(path.join(__dirname + '../public')));
 
 app.listen(PORT, () => {
   console.log(`App listening on port ${PORT}`);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "app.js",
+    "start": "node app.js",
     "dev": "nodemon app.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- fix npm start script to run app with Node
- correctly resolve static assets path in Express app

## Testing
- `npm test`
- `npm start` *(fails: Cannot init client. Please provide correct options)*

------
https://chatgpt.com/codex/tasks/task_e_689576a834a0832ab5ac4bea9aa8058b